### PR TITLE
fix test failures with PERL_UNICODE

### DIFF
--- a/t/getrandom.t
+++ b/t/getrandom.t
@@ -64,7 +64,7 @@ _OUT_
 			} elsif (defined $pid) {
 				local $ENV{LD_PRELOAD} = $binary_path;
 				eval {
-					exec { $^X } $^X, (map { "-I$_" } @INC), @extra_args, '-MCrypt::URandom', '-e', 'my $data = Crypt::URandom::getrandom(' . $correct_length . '); print "$data\n"; exit 0;' or die "Failed to exec $^X:$!";
+					exec { $^X } $^X, (map { "-I$_" } @INC), @extra_args, '-MCrypt::URandom', '-e', 'binmode STDOUT; my $data = Crypt::URandom::getrandom(' . $correct_length . '); print "$data\n"; exit 0;' or die "Failed to exec $^X:$!";
 				} or do {
 					warn "$@";
 				};
@@ -106,7 +106,7 @@ _OUT_
 			} elsif (defined $pid) {
 				local $ENV{LD_PRELOAD} = $binary_path;
 				eval {
-					exec { $^X } $^X, (map { "-I$_" } @INC), @extra_args, '-MEncode', '-MCrypt::URandom', '-e', 'eval { Crypt::URandom::getrandom(28); } or do { print Encode::encode("UTF-8", "$!\t$@\n"); exit 0 }; exit 1;' or die "Failed to exec $^X:$!";
+					exec { $^X } $^X, (map { "-I$_" } @INC), @extra_args, '-MEncode', '-MCrypt::URandom', '-e', 'binmode STDOUT; eval { Crypt::URandom::getrandom(28); } or do { print Encode::encode("UTF-8", "$!\t$@\n"); exit 0 }; exit 1;' or die "Failed to exec $^X:$!";
 				} or do {
 					warn "$@";
 				};


### PR DESCRIPTION
Mark STDOUT as binary before printing random bytes to it. Otherwise it will use the system default encoding, which may be UTF-8 if PERL_UNICODE=S or similar is set in the environment.

Fixes this error:

    t/getrandom.t .......... 1/? 
    #   Failed test 'getrandom hit with INT signal after 13 bytes recovers to produce correct length of 27 bytes:32'
    #   at t/getrandom.t line 61.
    # EAGAIN looks like 'Failed to getrandom:Resource temporarily unavailable at -e line 1.'
    # Looks like you failed 1 test of 6.